### PR TITLE
Port to VS 1.22 / .NET 10

### DIFF
--- a/spyglass/assets/spyglass/recipes/smithing/spytube.json
+++ b/spyglass/assets/spyglass/recipes/smithing/spytube.json
@@ -30,5 +30,6 @@
 		]
 	],
 	"name": "Spyglass Tube",
+	"code": "spyglass:spytube-{metal}",
 	"output": { "type": "item", "code": "spytube-{metal}"  }
 }

--- a/spyglass/modinfo.json
+++ b/spyglass/modinfo.json
@@ -11,6 +11,8 @@
 	"RequiredOnClient": true,
 	"RequiredOnServer": true,
 	"description": "Adds a spyglass so you can spy on your neighbors from the safety of your windmill!",
-	"version": "0.6.0",
-	"Dependencies": {}
+	"version": "0.6.1",
+	"Dependencies": {
+		"game": "1.22.0"
+	}
 }

--- a/spyglass/spyglass.csproj
+++ b/spyglass/spyglass.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>bin\$(Configuration)\Mods\mod</OutputPath>
   </PropertyGroup>

--- a/spyglass/src/Client/ClientPatcher.cs
+++ b/spyglass/src/Client/ClientPatcher.cs
@@ -47,7 +47,7 @@ namespace spyglass.src
 
         public void Stop()
         {
-            harmony.UnpatchAll();
+            harmony.UnpatchAll("spyglass");
         }
     }
 }


### PR DESCRIPTION
## Port to VS 1.22 / .NET 10

Builds clean against VS 1.22.2, smoke-tested in-game. The mod's API surface
already works on 1.22 — these are the four edits needed to silence the
build, the load-time warning, and the unscoped Harmony unpatch.

### Changes

- `TargetFramework`: `net7.0` → `net10.0`
- `modinfo.json`: bumped to 0.6.1, added `"game": "1.22.0"` dependency (bare
  semver, which is 1.22's minimum-version syntax; range/operator syntax
  doesn't parse in 1.22)
- Smithing recipe `spytube.json` carries a templated `code` per metal variant
  (`spyglass:spytube-{metal}`). 1.22 logs a warning for each of the 11 metal
  expansions without it, and 1.23 will require it
- `harmony.UnpatchAll()` scoped to the mod ID (`"spyglass"`). The zero-arg
  form would strip every Harmony patch from every loaded mod on dispose,
  not just Spyglass's

### Smoke test

- Loads as `spyglass@0.6.1` in VS 1.22.2 with no startup errors, no
  Harmony exceptions, no spyglass warnings in the log
- Spyglass crafts via grid recipe (`spytube` + glass plate), all 11 metal
  variants build
- Zoom works, vignette renders correctly, mouse-wheel zoom adjustment
  preserved
- Config sync from server to client (#8) still resolves cleanly

---

*`Tirello`*  
*ModDB · Forums · Discord*